### PR TITLE
[OSC-1240] - Refactor of commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ py mcd.py <db-connection-string> <command> -h
     - `base-path`: absolute or relative path to the models e.g.: `./load`, `/home/local/transform`, `C:/path/to/models`
     - `model-patterns`: one or more unix-style search patterns _(relative to `base-path`)_ for model files. models within a model-type must be named uniquely regardless of their file extension. e.g.: `*.txt`, `**/*.txt`, `./relative/path/to/some_models/**/*.csv`, `relative/path/to/some/more/related/models/**/*.sql`
   - `compare-models`: Compares the hashed checksums of models between two executions. Returns comma-separated string of changed model names.
-    - `old-execution-id`: identifier of an existing data pipeline execution, ideally as returned by the `get-last-successful-execution` command.
-    - `new-execution-id`: identifier of an existing data pipeline execution, ideally as returned by the `init` command.
+    - `previous-execution-id`: identifier of an existing data pipeline execution, ideally as returned by the `get-last-successful-execution` command.
+    - `current-execution-id`: identifier of an existing data pipeline execution, ideally as returned by the `init` command.
     - `model-type`: type of models being processed, choose from `LOAD`, `TRANSFORM`.
   - `complete-execution`: Marks the completion of an existing execution by updating a record for the same in the given database. Returns nothing unless there's an error.
     - `execution-id`: a GUID identifier of an existing data pipeline execution as returned by the `init` command.

--- a/README.md
+++ b/README.md
@@ -10,29 +10,33 @@ A utility that persists state of a data pipeline execution and uses them to dete
 py mcd.py [options] <command> [command-parameters]
 ```
 
+To get help,use:
+
+```commandline
+py mcd.py -h
+py mcd.py <db-connection-string> <command> -h
+```
+
 - `options` include:
   - `--help | -h`: displays help menu.
   - `--log-level | -l`: choose program's logging level, from CRITICAL, ERROR, WARNING, INFO, DEBUG; default is INFO.
 - `db-connection-string`: a [PostgreSQL Db Connection String](http://docs.sqlalchemy.org/en/latest/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg2) of the format `postgresql+psycopg2://user:password@host:port/dbname`
 - `command` is the function to be performed by the utility. The currently supported values are:
-  - `init`: Marks the start of a new execution by creating a record for the same in the given database. Returns an `execution-id` which is a GUID identifier of the new execution.
+  - `init-execution`: Marks the start of a new execution by creating a record for the same in the given database. Returns an `execution-id` which is a GUID identifier of the new execution.
   - `get-last-successful-execution`: Finds the last successful data pipeline execution. Returns an `execution-id` which is a GUID identifier of the new execution, if found; else returns and empty string.
   - `get-execution-last-updated-timestamp`: Returns the `last-updated-on` timestamp with timezone of the given `execution-id`. Raises error if given `execution-id` is invalid.
     - `execution-id`: a GUID identifier of an existing data pipeline execution.
-  - `compare`: Compares & persists SHA256-hashed checksums of the given models against those of the last successful execution. Returns comma-separated string of changed model names.
+  - `persist-models`: Saves models of the given `model-type` within the given `execution-id` by persisting hashed checksums of the given models.
+    - `execution-id`: identifier of an existing data pipeline execution, ideally as returned by the `init` command.
+    - `model-type`: type of models being processed, choose from `LOAD`, `TRANSFORM`.
+    - `base-path`: absolute or relative path to the models e.g.: `./load`, `/home/local/transform`, `C:/path/to/models`
+    - `model-patterns`: one or more unix-style search patterns _(relative to `base-path`)_ for model files. models within a model-type must be named uniquely regardless of their file extension. e.g.: `*.txt`, `**/*.txt`, `./relative/path/to/some_models/**/*.csv`, `relative/path/to/some/more/related/models/**/*.sql`
+  - `compare-models`: Compares the hashed checksums of models between two executions. Returns comma-separated string of changed model names.
+    - `old-execution-id`: identifier of an existing data pipeline execution, ideally as returned by the `get-last-successful-execution` command.
+    - `new-execution-id`: identifier of an existing data pipeline execution, ideally as returned by the `init` command.
+    - `model-type`: type of models being processed, choose from `LOAD`, `TRANSFORM`.
+  - `complete-execution`: Marks the completion of an existing execution by updating a record for the same in the given database. Returns nothing unless there's an error.
     - `execution-id`: a GUID identifier of an existing data pipeline execution as returned by the `init` command.
-    - `model-type`: type of models being processed e.g.: `load`, `transform`, etc. this `model-type` is used to group the model checksums by and used to find and compare older ones.
-    - `base-path`: absolute or relative path to the models e.g.: `./load`, `/home/local/load`, `C:/path/to/load`
-    - `model-patterns`: path-based patterns _(relative to `base-path`)_ to different models with extensions. models within a model-type must be named uniquely regardless of their file extension. e.g.: `*.txt`, `**/*.txt`, `./relative/path/to/some_models/**/*.csv`, `relative/path/to/some/more/related/models/**/*.sql`
-  - `complete`: Marks the completion of an existing execution by updating a record for the same in the given database. Returns nothing unless there's an error.
-    - `execution-id`: a GUID identifier of an existing data pipeline execution as returned by the `init` command.
-
-To get help,use:
-
-```commandline
-py mcd.py --help
-py mcd.py <command> --help
-```
 
 ### As a script
 
@@ -48,10 +52,18 @@ new-env\scripts\activate
 
 py -m pip install -r requirements.txt
 
-py mcd.py postgresql+psycopg2://user:password@host:port/dbname init
-py mcd.py postgresql+psycopg2://user:password@host:port/dbname compare execution-id-as-retured-by-init-command load ./relative/path/to/load/models **/*.json
-py mcd.py postgresql+psycopg2://user:password@host:port/dbname compare execution-id-as-retured-by-init-command transform C:/absolute/path/to/transform/models group1/*.csv ./group2/**/*.sql
-py mcd.py postgresql+psycopg2://user:password@host:port/dbname complete execution-id-as-retured-by-init-command
+py mcd.py postgresql+psycopg2://user:password@host:port/dbname init-execution
+
+py mcd.py postgresql+psycopg2://user:password@host:port/dbname get-last-successful-execution
+py mcd.py postgresql+psycopg2://user:password@host:port/dbname get-execution-last-updated-timestamp id-as-returned-by-get-last-successful-execution-command
+
+py mcd.py postgresql+psycopg2://user:password@host:port/dbname persist-models id-as-retured-by-init-command load ./relative/path/to/load/models **/*.json
+py mcd.py postgresql+psycopg2://user:password@host:port/dbname compare-models id-as-retured-by-get-last-successful-execution-command id-as-retured-by-init-command load
+
+py mcd.py postgresql+psycopg2://user:password@host:port/dbname persist-models id-as-retured-by-init-command transform C:/absolute/path/to/transform/models group1/*.csv ./group2/**/*.sql
+py mcd.py postgresql+psycopg2://user:password@host:port/dbname compare-models id-as-retured-by-get-last-successful-execution-command id-as-retured-by-init-command transform
+
+py mcd.py postgresql+psycopg2://user:password@host:port/dbname complete-execution id-as-retured-by-init-command
 ```
 
 ### As a package
@@ -74,10 +86,7 @@ new-env\scripts\activate
 
 pip install -e git+git://github.com/PageUpPeopleOrg/model-change-detector.git#egg=mcd
 
-py -m mcd postgresql+psycopg2://user:password@host:port/dbname init
-py -m mcd postgresql+psycopg2://user:password@host:port/dbname compare execution-id-as-retured-by-init-command load ./relative/path/to/load/models **/*.json
-py -m mcd postgresql+psycopg2://user:password@host:port/dbname compare execution-id-as-retured-by-init-command transform C:/absolute/path/to/transform/models group1/*.csv ./group2/**/*.sql
-py -m mcd postgresql+psycopg2://user:password@host:port/dbname complete execution-id-as-retured-by-init-command
+py -m mcd postgresql+psycopg2://user:password@host:port/dbname init-execution
 ```
 
 ## Setup

--- a/modules/DataRepository.py
+++ b/modules/DataRepository.py
@@ -1,5 +1,6 @@
-from sqlalchemy import desc
-
+from sqlalchemy import desc, select
+from sqlalchemy.sql import func
+from sqlalchemy.orm import sessionmaker
 from modules import Shared
 from modules.BaseObject import BaseObject
 from modules.Shared import Constants
@@ -8,13 +9,17 @@ from modules.entities.ModelChecksumEntity import ModelChecksumEntity
 
 
 class DataRepository(BaseObject):
-    def __init__(self, session_maker, logger=None):
+    def __init__(self, db_engine, logger=None):
         super().__init__(logger)
-        self.session_maker = session_maker
+        self.db_engine = db_engine
+        self.session_maker = sessionmaker(bind=self.db_engine)
 
-    def ensure_schema_exists(self, engine):
-        engine.execute(f'CREATE SCHEMA IF NOT EXISTS {Constants.DATA_PIPELINE_EXECUTION_SCHEMA_NAME}')
-        Shared.BaseEntity.metadata.create_all(engine)
+    def ensure_schema_exists(self):
+        self.db_engine.execute(f'CREATE SCHEMA IF NOT EXISTS {Constants.DATA_PIPELINE_EXECUTION_SCHEMA_NAME}')
+        Shared.BaseEntity.metadata.create_all(self.db_engine)
+
+    def get_current_db_datetime_with_timezone(self):
+        return self.db_engine.execute(select([func.now()])).fetchone()[0]
 
     def initialise_execution(self):
         session = self.session_maker()
@@ -27,46 +32,38 @@ class DataRepository(BaseObject):
 
     def get_execution(self, execution_id):
         session = self.session_maker()
-        return session.query(DataPipelineExecutionEntity) \
+        result = session.query(DataPipelineExecutionEntity) \
             .filter_by(id=execution_id) \
             .first()
+        session.close()
+        return result
 
     def get_last_successful_execution(self):
         session = self.session_maker()
-        return session.query(DataPipelineExecutionEntity) \
+        result = session.query(DataPipelineExecutionEntity) \
             .filter_by(status=Constants.DataPipelineExecutionStatus.COMPLETED) \
             .order_by(desc(DataPipelineExecutionEntity.last_updated_on)) \
             .order_by(desc(DataPipelineExecutionEntity.created_on)) \
             .first()
+        session.close()
+        return result
 
-    def get_last_successful_models(self, model_type):
-        last_successful_models = {}
+    def get_execution_models(self, execution_id, model_type):
         session = self.session_maker()
+        results = session.query(ModelChecksumEntity) \
+            .filter_by(execution_id=execution_id, type=model_type)
+        session.close()
+        return [r for r in results]
 
-        last_successful_execution = session.query(DataPipelineExecutionEntity) \
-            .filter_by(status=Constants.DataPipelineExecutionStatus.COMPLETED) \
-            .order_by(desc(DataPipelineExecutionEntity.last_updated_on)) \
-            .order_by(desc(DataPipelineExecutionEntity.created_on)) \
-            .first()
-
-        if last_successful_execution is None:
-            return last_successful_models
-
-        previous_model_checksums = session.query(ModelChecksumEntity) \
-            .filter_by(execution_id=last_successful_execution.id, type=model_type)
-
-        for model_checksum_entity in previous_model_checksums:
-            last_successful_models[model_checksum_entity.name] = model_checksum_entity.checksum
-
-        return last_successful_models
-
-    def save_execution_progress(self, execution_id, model_type, model_checksums):
+    def save_execution_models(self, execution_id, model_type, model_checksums):
         session = self.session_maker()
 
         data_pipeline_execution = session.query(DataPipelineExecutionEntity) \
             .filter_by(id=execution_id) \
             .one()
 
+        data_pipeline_execution.status = \
+            Constants.DataPipelineExecutionStatus.MODEL_TYPE_IN_PROCESS.format(model_type=model_type)
         for model, checksum in sorted(model_checksums.items()):
             model_checksum_entity = ModelChecksumEntity(execution_id=data_pipeline_execution.id,
                                                         type=model_type,
@@ -75,6 +72,7 @@ class DataRepository(BaseObject):
             session.add(model_checksum_entity)
 
         session.commit()
+
         return data_pipeline_execution
 
     def complete_execution(self, execution_id):
@@ -83,7 +81,12 @@ class DataRepository(BaseObject):
         data_pipeline_execution = session.query(DataPipelineExecutionEntity) \
             .filter_by(id=execution_id) \
             .one()
+
         data_pipeline_execution.status = Constants.DataPipelineExecutionStatus.COMPLETED
+        data_pipeline_execution.last_updated_on = self.get_current_db_datetime_with_timezone()
+        data_pipeline_execution.execution_time_ms \
+            = (data_pipeline_execution.last_updated_on - data_pipeline_execution.created_on).total_seconds() * 1000
 
         session.commit()
+
         return data_pipeline_execution

--- a/modules/DataRepository.py
+++ b/modules/DataRepository.py
@@ -53,7 +53,7 @@ class DataRepository(BaseObject):
         results = session.query(ModelChecksumEntity) \
             .filter_by(execution_id=execution_id, type=model_type)
         session.close()
-        return [r for r in results]
+        return results.all()
 
     def save_execution_models(self, execution_id, model_type, model_checksums):
         session = self.session_maker()

--- a/modules/DataRepository.py
+++ b/modules/DataRepository.py
@@ -63,7 +63,7 @@ class DataRepository(BaseObject):
             .one()
 
         data_pipeline_execution.status = \
-            Constants.DataPipelineExecutionStatus.MODEL_TYPE_IN_PROCESS.format(model_type=model_type)
+            Constants.DataPipelineExecutionStatus.IN_PROGRESS
         for model, checksum in sorted(model_checksums.items()):
             model_checksum_entity = ModelChecksumEntity(execution_id=data_pipeline_execution.id,
                                                         type=model_type,

--- a/modules/ModelChangeDetector.py
+++ b/modules/ModelChangeDetector.py
@@ -41,7 +41,7 @@ class ModelChangeDetector(BaseObject):
 
     def __process_compare_models_command(self):
         CompareModelsCommand(
-            self.args.db_connection_string, self.args.old_execution_id, self.args.new_execution_id,
+            self.args.db_connection_string, self.args.previous_execution_id, self.args.current_execution_id,
             self.args.model_type.upper()
         ).execute()
 
@@ -118,13 +118,13 @@ class ModelChangeDetector(BaseObject):
                  'Returns comma-separated string of changed model names.')
         compare_models_command_parser.set_defaults(func=self.__process_compare_models_command)
         compare_models_command_parser.add_argument(
-            'old_execution_id',
-            metavar='old-execution-id',
+            'previous_execution_id',
+            metavar='previous-execution-id',
             help='identifier of an existing data pipeline execution, '
                  'ideally as returned by the \'get-last-successful-execution\' command.')
         compare_models_command_parser.add_argument(
-            'new_execution_id',
-            metavar='new-execution-id',
+            'current_execution_id',
+            metavar='current-execution-id',
             help='identifier of an existing data pipeline execution, ideally as returned by the \'init\' command.')
         compare_models_command_parser.add_argument(
             'model_type',

--- a/modules/ModelChangeDetector.py
+++ b/modules/ModelChangeDetector.py
@@ -4,11 +4,12 @@ import logging
 from modules import Shared
 from modules.BaseObject import BaseObject
 from modules.Shared import Constants
-from modules.commands.GetExecutionLastUpdateTimestampCommand import GetExecutionLastUpdateTimestampCommand
+from modules.commands.InitialiseExecutionCommand import InitialiseExecutionCommand
 from modules.commands.GetLastSuccessfulExecutionCommand import GetLastSuccessfulExecutionCommand
-from modules.commands.CompareCommand import CompareCommand
-from modules.commands.CompleteCommand import CompleteCommand
-from modules.commands.InitialiseCommand import InitialiseCommand
+from modules.commands.GetExecutionLastUpdateTimestampCommand import GetExecutionLastUpdateTimestampCommand
+from modules.commands.PersistModelsCommand import PersistModelsCommand
+from modules.commands.CompareModelsCommand import CompareModelsCommand
+from modules.commands.CompleteExecutionCommand import CompleteExecutionCommand
 
 
 class ModelChangeDetector(BaseObject):
@@ -23,8 +24,8 @@ class ModelChangeDetector(BaseObject):
 
         self.args.func()
 
-    def __process_init_command(self):
-        InitialiseCommand(self.args.db_connection_string).execute()
+    def __process_init_execution_command(self):
+        InitialiseExecutionCommand(self.args.db_connection_string).execute()
 
     def __process_get_execution_last_updated_timestamp_command(self):
         GetExecutionLastUpdateTimestampCommand(self.args.db_connection_string, self.args.execution_id).execute()
@@ -32,12 +33,20 @@ class ModelChangeDetector(BaseObject):
     def __process_get_last_successful_execution_command(self):
         GetLastSuccessfulExecutionCommand(self.args.db_connection_string).execute()
 
-    def __process_compare_command(self):
-        CompareCommand(self.args.db_connection_string, self.args.execution_id, self.args.model_type,
-                       self.args.base_path, self.args.model_patterns).execute()
+    def __process_save_models_command(self):
+        PersistModelsCommand(
+            self.args.db_connection_string, self.args.execution_id, self.args.model_type.upper(),
+            self.args.base_path, self.args.model_patterns
+        ).execute()
 
-    def __process_complete_command(self):
-        CompleteCommand(self.args.db_connection_string, self.args.execution_id).execute()
+    def __process_compare_models_command(self):
+        CompareModelsCommand(
+            self.args.db_connection_string, self.args.old_execution_id, self.args.new_execution_id,
+            self.args.model_type.upper()
+        ).execute()
+
+    def __process_complete_execution_command(self):
+        CompleteExecutionCommand(self.args.db_connection_string, self.args.execution_id).execute()
 
     def __get_arguments(self):
         parser = argparse.ArgumentParser(
@@ -55,8 +64,9 @@ class ModelChangeDetector(BaseObject):
 
         subparsers = parser.add_subparsers(title='commands', metavar='', dest='command')
 
-        init_command_parser = subparsers.add_parser('init', help='initialises a new data pipeline execution')
-        init_command_parser.set_defaults(func=self.__process_init_command)
+        init_execution_command_parser = subparsers.add_parser(
+            'init-execution', help='initialises a new data pipeline execution')
+        init_execution_command_parser.set_defaults(func=self.__process_init_execution_command)
 
         get_last_successful_execution_command_parser = subparsers.add_parser(
             'get-last-successful-execution',
@@ -67,7 +77,7 @@ class ModelChangeDetector(BaseObject):
 
         get_execution_last_updated_timestamp_command_parser = subparsers.add_parser(
             'get-execution-last-updated-timestamp',
-            help='returns the last-updated-on timestamp-with-timezone of a given execution-id. '
+            help='returns the last-updated-on timestamp (datetime with timezone) of a given execution-id. '
                  'raises error if given execution-id is invalid.')
         get_execution_last_updated_timestamp_command_parser.set_defaults(
             func=self.__process_get_execution_last_updated_timestamp_command)
@@ -76,35 +86,55 @@ class ModelChangeDetector(BaseObject):
             metavar='execution-id',
             help='an existing data pipeline execution id')
 
-        compare_command_parser = subparsers.add_parser(
-            'compare',
-            help='compares given models with those of the last successfully processed data pipeline execution. '
-                 'also persists given models against the given data pipeline execution.')
-        compare_command_parser.set_defaults(func=self.__process_compare_command)
-        compare_command_parser.add_argument(
+        persist_models_command_parser = subparsers.add_parser(
+            'persist-models',
+            help='Saves models of the given \'model-type\' within the given \'execution-id\' '
+                 'by persisting hashed checksums of the given models.')
+        persist_models_command_parser.set_defaults(func=self.__process_save_models_command)
+        persist_models_command_parser.add_argument(
             'execution_id',
             metavar='execution-id',
-            help='data pipeline execution id as received using \'init\' command')
-        compare_command_parser.add_argument(
+            help='identifier of an existing data pipeline execution, ideally as returned by the \'init\' command.')
+        persist_models_command_parser.add_argument(
             'model_type',
             metavar='model-type',
-            help='a string name for the type of models to compare. used to group models between various calls to this '
-                 'command for same data pipeline execution. e.g. load, transform')
-        compare_command_parser.add_argument(
+            help=f'type of models being processed, choose from {", ".join(Shared.MODEL_TYPES)}.')
+        persist_models_command_parser.add_argument(
             'base_path',
             metavar='base-path',
-            help='absolute or relative path to the base directory of all models')
-        compare_command_parser.add_argument(
+            help='absolute or relative path to the base directory of all models'
+                 'e.g.: ./load, /home/local/transform, C:/path/to/models')
+        persist_models_command_parser.add_argument(
             'model_patterns',
             metavar='model-patterns',
             nargs='+',
-            help='one or more unix-style search patterns for model files. '
+            help='one or more unix-style search patterns (relative to \'base-path\') for model files. '
+                 'models within a model-type must be named uniquely regardless of their file extension.'
                  'e.g.: *.txt, **/*.json, ./path/to/some_models/**/*.csv, path/to/some/more/related/models/**/*.sql')
 
-        complete_command_parser = subparsers.add_parser(
-            'complete', help='completes the given data pipeline execution.')
-        complete_command_parser.set_defaults(func=self.__process_complete_command)
-        complete_command_parser.add_argument(
+        compare_models_command_parser = subparsers.add_parser(
+            'compare-models',
+            help='Compares the hashed checksums of models between two executions. '
+                 'Returns comma-separated string of changed model names.')
+        compare_models_command_parser.set_defaults(func=self.__process_compare_models_command)
+        compare_models_command_parser.add_argument(
+            'old_execution_id',
+            metavar='old-execution-id',
+            help='identifier of an existing data pipeline execution, '
+                 'ideally as returned by the \'get-last-successful-execution\' command.')
+        compare_models_command_parser.add_argument(
+            'new_execution_id',
+            metavar='new-execution-id',
+            help='identifier of an existing data pipeline execution, ideally as returned by the \'init\' command.')
+        compare_models_command_parser.add_argument(
+            'model_type',
+            metavar='model-type',
+            help=f'type of models being processed, choose from {", ".join(Shared.MODEL_TYPES)}.')
+
+        complete_execution_command_parser = subparsers.add_parser(
+            'complete-execution', help='completes the given data pipeline execution.')
+        complete_execution_command_parser.set_defaults(func=self.__process_complete_execution_command)
+        complete_execution_command_parser.add_argument(
             'execution_id',
             metavar='execution-id',
             help='data pipeline execution id as received using \'init\' command')

--- a/modules/Shared.py
+++ b/modules/Shared.py
@@ -12,7 +12,7 @@ class Constants:
 
     class DataPipelineExecutionStatus:
         INITIALISED = 'INITIALISED'
-        MODEL_TYPE_IN_PROCESS = '{model_type}_IN_PROCESS'
+        IN_PROGRESS = 'IN_PROGRESS'
         COMPLETED = 'COMPLETED'
 
     class ModelType:

--- a/modules/Shared.py
+++ b/modules/Shared.py
@@ -8,11 +8,19 @@ BaseEntity = declarative_base()
 class Constants:
     APP_NAME = 'model-change-detector'
     DATA_PIPELINE_EXECUTION_SCHEMA_NAME = 'data_pipeline'
+    NO_LAST_SUCCESSFUL_EXECUTION = 'NO_LAST_SUCCESSFUL_EXECUTION'
 
     class DataPipelineExecutionStatus:
         INITIALISED = 'INITIALISED'
+        MODEL_TYPE_IN_PROCESS = '{model_type}_IN_PROCESS'
         COMPLETED = 'COMPLETED'
 
+    class ModelType:
+        LOAD = 'LOAD'
+        TRANSFORM = 'TRANSFORM'
+
+
+MODEL_TYPES = [Constants.ModelType.LOAD, Constants.ModelType.TRANSFORM]
 
 _logLevelStrings = [logging.getLevelName(logging.CRITICAL),
                     logging.getLevelName(logging.ERROR),
@@ -50,7 +58,7 @@ def get_default_arguments():
                         type=get_log_level_int_from_string,
                         nargs='?',
                         help=f'choose program\'s logging level, from {", ".join(_logLevelStrings)}; '
-                             f'default is {_defaultLogLevelString}')
+                        f'default is {_defaultLogLevelString}')
 
     return parser
 

--- a/modules/commands/BaseCommand.py
+++ b/modules/commands/BaseCommand.py
@@ -1,5 +1,4 @@
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 from modules.DataRepository import DataRepository
 from modules.BaseObject import BaseObject
 
@@ -8,6 +7,5 @@ class BaseCommand(BaseObject):
     def __init__(self, db_connection_string, logger=None):
         super().__init__(logger)
         self.db_engine = create_engine(db_connection_string, echo=False)
-        self.session_maker = sessionmaker(bind=self.db_engine)
-        self.repository = DataRepository(self.session_maker)
-        self.repository.ensure_schema_exists(engine=self.db_engine)
+        self.repository = DataRepository(self.db_engine)
+        self.repository.ensure_schema_exists()

--- a/modules/commands/BaseCommand.py
+++ b/modules/commands/BaseCommand.py
@@ -9,3 +9,9 @@ class BaseCommand(BaseObject):
         self.db_engine = create_engine(db_connection_string, echo=False)
         self.repository = DataRepository(self.db_engine)
         self.repository.ensure_schema_exists()
+
+    def execute(self):
+        raise NotImplementedError()
+
+    def output(self, *args):
+        raise NotImplementedError()

--- a/modules/commands/CompareModelsCommand.py
+++ b/modules/commands/CompareModelsCommand.py
@@ -3,17 +3,17 @@ from modules.Shared import Constants
 
 
 class CompareModelsCommand(BaseCommand):
-    def __init__(self, db_connection_string, old_execution_id, new_execution_id, model_type, logger=None):
+    def __init__(self, db_connection_string, previous_execution_id, current_execution_id, model_type, logger=None):
         super().__init__(db_connection_string, logger)
-        self._old_execution_id = old_execution_id
-        self._new_execution_id = new_execution_id
+        self._previous_execution_id = previous_execution_id
+        self._current_execution_id = current_execution_id
         self._model_type = model_type
         self._changed_models_separator = ' '
 
     def execute(self):
-        old_models = [] if self._old_execution_id == Constants.NO_LAST_SUCCESSFUL_EXECUTION \
-            else self.repository.get_execution_models(self._old_execution_id, self._model_type)
-        new_models = self.repository.get_execution_models(self._new_execution_id, self._model_type)
+        old_models = [] if self._previous_execution_id == Constants.NO_LAST_SUCCESSFUL_EXECUTION \
+            else self.repository.get_execution_models(self._previous_execution_id, self._model_type)
+        new_models = self.repository.get_execution_models(self._current_execution_id, self._model_type)
 
         # kept for later validation
         # if len(old_models) == 0:

--- a/modules/commands/CompareModelsCommand.py
+++ b/modules/commands/CompareModelsCommand.py
@@ -11,28 +11,24 @@ class CompareModelsCommand(BaseCommand):
         self._changed_models_separator = ' '
 
     def execute(self):
-        old_models = [] if self._previous_execution_id == Constants.NO_LAST_SUCCESSFUL_EXECUTION \
+        previous_models_list = [] if self._previous_execution_id == Constants.NO_LAST_SUCCESSFUL_EXECUTION \
             else self.repository.get_execution_models(self._previous_execution_id, self._model_type)
-        new_models = self.repository.get_execution_models(self._current_execution_id, self._model_type)
+        current_models_list = self.repository.get_execution_models(self._current_execution_id, self._model_type)
 
-        # kept for later validation
-        # if len(old_models) == 0:
-        #     self.logger.debug(f'Changed models: ALL')
-        #     print('*')
-        #     return
+        previous_model_checksums = {}
+        for model in previous_models_list:
+            previous_model_checksums[model.name] = model.checksum
 
-        old_model_checksums = {}
-        for model in old_models:
-            old_model_checksums[model.name] = model.checksum
+        current_model_checksums = {}
+        for model in current_models_list:
+            current_model_checksums[model.name] = model.checksum
 
-        new_model_checksums = {}
-        for model in new_models:
-            new_model_checksums[model.name] = model.checksum
+        changed_models_list = []
+        for model, new_checksum in current_model_checksums.items():
+            if model not in previous_model_checksums or previous_model_checksums[model] != new_checksum:
+                changed_models_list.append(model)
 
-        changed_models = []
-        for model, new_checksum in new_model_checksums.items():
-            if model not in old_model_checksums or old_model_checksums[model] != new_checksum:
-                changed_models.append(model)
+        self.output(changed_models_list)
 
-        print(self._changed_models_separator.join(changed_models))
-        self.logger.debug(f'Changed models: \'${str(changed_models)}\'')
+    def output(self, changed_models_list):
+        print(self._changed_models_separator.join(changed_models_list))

--- a/modules/commands/CompareModelsCommand.py
+++ b/modules/commands/CompareModelsCommand.py
@@ -1,0 +1,38 @@
+from modules.commands.BaseCommand import BaseCommand
+from modules.Shared import Constants
+
+
+class CompareModelsCommand(BaseCommand):
+    def __init__(self, db_connection_string, old_execution_id, new_execution_id, model_type, logger=None):
+        super().__init__(db_connection_string, logger)
+        self._old_execution_id = old_execution_id
+        self._new_execution_id = new_execution_id
+        self._model_type = model_type
+        self._changed_models_separator = ' '
+
+    def execute(self):
+        old_models = [] if self._old_execution_id == Constants.NO_LAST_SUCCESSFUL_EXECUTION \
+            else self.repository.get_execution_models(self._old_execution_id, self._model_type)
+        new_models = self.repository.get_execution_models(self._new_execution_id, self._model_type)
+
+        # kept for later validation
+        # if len(old_models) == 0:
+        #     self.logger.debug(f'Changed models: ALL')
+        #     print('*')
+        #     return
+
+        old_model_checksums = {}
+        for model in old_models:
+            old_model_checksums[model.name] = model.checksum
+
+        new_model_checksums = {}
+        for model in new_models:
+            new_model_checksums[model.name] = model.checksum
+
+        changed_models = []
+        for model, new_checksum in new_model_checksums.items():
+            if model not in old_model_checksums or old_model_checksums[model] != new_checksum:
+                changed_models.append(model)
+
+        print(self._changed_models_separator.join(changed_models))
+        self.logger.debug(f'Changed models: \'${str(changed_models)}\'')

--- a/modules/commands/CompleteExecutionCommand.py
+++ b/modules/commands/CompleteExecutionCommand.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from modules.commands.BaseCommand import BaseCommand
 
 
-class CompleteCommand(BaseCommand):
+class CompleteExecutionCommand(BaseCommand):
     def __init__(self, db_connection_string, execution_id, logger=None):
         super().__init__(db_connection_string, logger)
         self._execution_id = execution_id

--- a/modules/commands/GetExecutionLastUpdateTimestampCommand.py
+++ b/modules/commands/GetExecutionLastUpdateTimestampCommand.py
@@ -1,5 +1,5 @@
 from modules.commands.BaseCommand import BaseCommand
-from datetime import datetime
+from modules.Shared import Constants
 
 
 class GetExecutionLastUpdateTimestampCommand(BaseCommand):
@@ -8,8 +8,14 @@ class GetExecutionLastUpdateTimestampCommand(BaseCommand):
         self._execution_id = execution_id
 
     def execute(self):
+        if self._execution_id == Constants.NO_LAST_SUCCESSFUL_EXECUTION:
+            self.logger.debug('Received no execution id, so returning current database datetime with timezone')
+            return self.output(self.repository.get_current_db_datetime_with_timezone())
+
         data_pipeline_execution = self.repository.get_execution(self._execution_id)
-        self.logger.debug(f'Found requested data_pipeline_execution to be {data_pipeline_execution}')
         if data_pipeline_execution is None:
             raise ValueError(self._execution_id)
-        print(data_pipeline_execution.last_updated_on.isoformat())
+        return self.output(data_pipeline_execution.last_updated_on)
+
+    def output(self, timestamp):
+        print(timestamp.isoformat())

--- a/modules/commands/GetExecutionLastUpdateTimestampCommand.py
+++ b/modules/commands/GetExecutionLastUpdateTimestampCommand.py
@@ -10,12 +10,14 @@ class GetExecutionLastUpdateTimestampCommand(BaseCommand):
     def execute(self):
         if self._execution_id == Constants.NO_LAST_SUCCESSFUL_EXECUTION:
             self.logger.debug('Received no execution id, so returning current database datetime with timezone')
-            return self.output(self.repository.get_current_db_datetime_with_timezone())
+            self.output(self.repository.get_current_db_datetime_with_timezone())
+            return 
 
         data_pipeline_execution = self.repository.get_execution(self._execution_id)
         if data_pipeline_execution is None:
             raise ValueError(self._execution_id)
-        return self.output(data_pipeline_execution.last_updated_on)
+        self.output(data_pipeline_execution.last_updated_on)
+        return 
 
     def output(self, timestamp):
         print(timestamp.isoformat())

--- a/modules/commands/GetExecutionLastUpdateTimestampCommand.py
+++ b/modules/commands/GetExecutionLastUpdateTimestampCommand.py
@@ -11,13 +11,13 @@ class GetExecutionLastUpdateTimestampCommand(BaseCommand):
         if self._execution_id == Constants.NO_LAST_SUCCESSFUL_EXECUTION:
             self.logger.debug('Received no execution id, so returning current database datetime with timezone')
             self.output(self.repository.get_current_db_datetime_with_timezone())
-            return 
+            return
 
         data_pipeline_execution = self.repository.get_execution(self._execution_id)
         if data_pipeline_execution is None:
             raise ValueError(self._execution_id)
         self.output(data_pipeline_execution.last_updated_on)
-        return 
+        return
 
     def output(self, timestamp):
         print(timestamp.isoformat())

--- a/modules/commands/GetLastSuccessfulExecutionCommand.py
+++ b/modules/commands/GetLastSuccessfulExecutionCommand.py
@@ -1,4 +1,5 @@
 from modules.commands.BaseCommand import BaseCommand
+from modules.Shared import Constants
 
 
 class GetLastSuccessfulExecutionCommand(BaseCommand):
@@ -8,4 +9,5 @@ class GetLastSuccessfulExecutionCommand(BaseCommand):
     def execute(self):
         data_pipeline_execution = self.repository.get_last_successful_execution()
         self.logger.debug('Found last successful data_pipeline_execution to be ' + str(data_pipeline_execution))
-        print(str(data_pipeline_execution.id) if data_pipeline_execution is not None else '')
+        print(str(data_pipeline_execution.id) if data_pipeline_execution is not None
+              else Constants.NO_LAST_SUCCESSFUL_EXECUTION)

--- a/modules/commands/GetLastSuccessfulExecutionCommand.py
+++ b/modules/commands/GetLastSuccessfulExecutionCommand.py
@@ -9,5 +9,8 @@ class GetLastSuccessfulExecutionCommand(BaseCommand):
     def execute(self):
         data_pipeline_execution = self.repository.get_last_successful_execution()
         self.logger.debug('Found last successful data_pipeline_execution to be ' + str(data_pipeline_execution))
+        self.output(data_pipeline_execution)
+
+    def output(self, data_pipeline_execution):
         print(str(data_pipeline_execution.id) if data_pipeline_execution is not None
               else Constants.NO_LAST_SUCCESSFUL_EXECUTION)

--- a/modules/commands/InitialiseExecutionCommand.py
+++ b/modules/commands/InitialiseExecutionCommand.py
@@ -1,7 +1,7 @@
 from modules.commands.BaseCommand import BaseCommand
 
 
-class InitialiseCommand(BaseCommand):
+class InitialiseExecutionCommand(BaseCommand):
     def __init__(self, db_connection_string, logger=None):
         super().__init__(db_connection_string, logger)
 


### PR DESCRIPTION
a) split `compare` command into `persist-models` and `compare-models` command
b) rename `init` command to `init-execution`
c) rename `complete` command to `complete-execution`
d) until a successful execution is completed, all calls to retrieve the last successful one to now return constants NO_LAST_SUCCESSFUL_EXECUTION that is to be understood by other related commands
e) calculate execution time
f) return all models when all models have changed OR during first execution instead of `*` _(until consumers can handle `*`)_
g) update readme to reflect the above