### PR TITLE
[OSC-1247] Add coverage for all new commands in integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,5 +109,4 @@ venv.bak/
 # JetBrains
 .idea/
 
-test-models/
 tests/integration/models/

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,9 @@ verify_ssl = true
 
 [dev-packages]
 pytest = "*"
+pep8 = "*"
+pylint = "*"
+autopep8 = "*"
 
 [packages]
 psycopg2-binary = "==2.7.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4b5247abd0599a2ccaf58710229a286acfca9e8755c7f8fa5ec2c6a02139f19d"
+            "sha256": "2c64331c4a7a47f83b19e887f75ccefd426769341514943d20df7bf9ab8a5d86"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -61,6 +61,13 @@
         }
     },
     "develop": {
+        "astroid": {
+            "hashes": [
+                "sha256:bfa089d8ebeccc44c35fb06cc9ebf951d9b47b371d25dc14be85b30fef46267f",
+                "sha256:d76f540795deb23b2f4ca6d3e40ab4ff543fdb5c82c083664b8651a4cb129ac7"
+            ],
+            "version": "==2.2.2"
+        },
         "atomicwrites": {
             "hashes": [
                 "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
@@ -70,10 +77,73 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
+        },
+        "autopep8": {
+            "hashes": [
+                "sha256:33d2b5325b7e1afb4240814fe982eea3a92ebea712869bfd08b3c0393404248c"
+            ],
+            "index": "pypi",
+            "version": "==1.4.3"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
+                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.1"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:144c4295314c0ed34fb034f838b2b7e242c52dd3eafdd6f5d49078692f582c0c",
+                "sha256:92a7ddacb0e7e10ed2976e6b5d58496dcda27a3f525c187a3a1a0ae5fa79ff1b"
+            ],
+            "version": "==4.3.10"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:0ce34342b419bd8f018e6666bfef729aec3edf62345a53b537a4dcc115746a33",
+                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
+                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
+                "sha256:27bf62cb2b1a2068d443ff7097ee33393f8483b570b475db8ebf7e1cba64f088",
+                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
+                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
+                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
+                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
+                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
+                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
+                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
+                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
+                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
+                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
+                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
+                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
+                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
+                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
+                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
+                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
+                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
+                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
+                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
+                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
+                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
+                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
+                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
+                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a",
+                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b"
+            ],
+            "version": "==1.3.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
         },
         "more-itertools": {
             "hashes": [
@@ -82,6 +152,14 @@
             ],
             "markers": "python_version > '2.7'",
             "version": "==6.0.0"
+        },
+        "pep8": {
+            "hashes": [
+                "sha256:b22cfae5db09833bb9bd7c8463b53e1a9c9b39f12e304a8d0bba729c501827ee",
+                "sha256:fe249b52e20498e59e0b5c5256aa52ee99fc295b26ec9eaa85776ffdb9fe6374"
+            ],
+            "index": "pypi",
+            "version": "==1.7.1"
         },
         "pluggy": {
             "hashes": [
@@ -97,6 +175,21 @@
             ],
             "version": "==1.8.0"
         },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+            ],
+            "version": "==2.5.0"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
+                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
+            ],
+            "index": "pypi",
+            "version": "==2.3.1"
+        },
         "pytest": {
             "hashes": [
                 "sha256:067a1d4bf827ffdd56ad21bd46674703fce77c5957f6c1eef731f6146bfcef1c",
@@ -111,6 +204,37 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:035a54ede6ce1380599b2ce57844c6554666522e376bd111eb940fbc7c3dad23",
+                "sha256:037c35f2741ce3a9ac0d55abfcd119133cbd821fffa4461397718287092d9d15",
+                "sha256:049feae7e9f180b64efacbdc36b3af64a00393a47be22fa9cb6794e68d4e73d3",
+                "sha256:19228f7940beafc1ba21a6e8e070e0b0bfd1457902a3a81709762b8b9039b88d",
+                "sha256:2ea681e91e3550a30c2265d2916f40a5f5d89b59469a20f3bad7d07adee0f7a6",
+                "sha256:3a6b0a78af298d82323660df5497bcea0f0a4a25a0b003afd0ce5af049bd1f60",
+                "sha256:5385da8f3b801014504df0852bf83524599df890387a3c2b17b7caa3d78b1773",
+                "sha256:606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424",
+                "sha256:69245b5b23bbf7fb242c9f8f08493e9ecd7711f063259aefffaeb90595d62287",
+                "sha256:6f6d839ab09830d59b7fa8fb6917023d8cb5498ee1f1dbd82d37db78eb76bc99",
+                "sha256:730888475f5ac0e37c1de4bd05eeb799fdb742697867f524dc8a4cd74bcecc23",
+                "sha256:9819b5162ffc121b9e334923c685b0d0826154e41dfe70b2ede2ce29034c71d8",
+                "sha256:9e60ef9426efab601dd9aa120e4ff560f4461cf8442e9c0a2b92548d52800699",
+                "sha256:af5fbdde0690c7da68e841d7fc2632345d570768ea7406a9434446d7b33b0ee1",
+                "sha256:b64efdbdf3bbb1377562c179f167f3bf301251411eb5ac77dec6b7d32bcda463",
+                "sha256:bac5f444c118aeb456fac1b0b5d14c6a71ea2a42069b09c176f75e9bd4c186f6",
+                "sha256:bda9068aafb73859491e13b99b682bd299c1b5fd50644d697533775828a28ee0",
+                "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
+                "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
+            ],
+            "markers": "python_version >= '3.7' and implementation_name == 'cpython'",
+            "version": "==1.3.1"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
+            ],
+            "version": "==1.11.1"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ To run integration tests, please ensure the following information is configured 
 
 - `tests/integration/test_integration.sh:9`
 
-Please ensure that the database connection string points to a valid PostgreSQL instance.
+Please ensure that the database connection string points to a valid PostgreSQL instance with valid parameters.
 
 #### Docker
 

--- a/tests/integration/test_integration.sh
+++ b/tests/integration/test_integration.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Exit on failure
 set -e

--- a/tests/integration/test_integration.sh
+++ b/tests/integration/test_integration.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Bootstrap
-mcd="pipenv run python -m mcd postgresql+psycopg2://postgres:password@localhost:5432/postgres"
+mcd="pipenv run python -m mcd postgresql+psycopg2://postgres:travisci@localhost:5432/postgres"
 modelDirectory="./tests/integration/models"
 loadModelDirectory="$modelDirectory/load"
 transformModelDirectory="$modelDirectory/transform"

--- a/tests/integration/test_integration.sh
+++ b/tests/integration/test_integration.sh
@@ -4,27 +4,61 @@
 set -e
 
 # Bootstrap
-## Aliases
-modelDirectory="./tests/integration/models"
-loadModelDirectory="$modelDirectory/load"
-transformModelDirectory="$modelDirectory/transform"
-mcd="pipenv run python -m mcd postgresql+psycopg2://postgres:postgres@localhost:5432/postgres"
+mcd="pipenv run python -m mcd postgresql+psycopg2://postgres:password@localhost:5432/postgres"
+
+# Generate a pseudo UUID
+NewUUID () {
+    local N B C='89ab'
+
+    for (( N=0; N < 16; ++N ))
+    do
+        B=$(( $RANDOM%256 ))
+
+        case $N in
+            6)
+                printf '4%x' $(( B%16 ))
+                ;;
+            8)
+                printf '%c%x' ${C:$RANDOM%${#C}:1} $(( B%16 ))
+                ;;
+            3 | 5 | 7 | 9)
+                printf '%02x-' $B
+                ;;
+            *)
+                printf '%02x' $B
+                ;;
+        esac
+    done
+
+    echo
+}
+
+LogErrorAndExit () {
+    local errorText=$1
+    local errorCode=1
+
+    >&2 echo ${errorText}
+    exit $errorCode
+}
+
+AssertAreEqual () {
+    local actual=$1
+    local expected=$2
+    if [ "$actual" != "$expected" ]
+    then
+        LogErrorAndExit "ERROR: expected "$expected", actual "$actual""
+    fi
+}
 
 InitExecution () {
     local executionId=$($mcd init-execution)
 
     if [ ${#executionId} -ne 36 ]
     then
-        echo "ERROR: expected a non-empty guid-length execution identifier, actual "$executionId""
-        exit 1
+        LogErrorAndExit "ERROR: expected a non-empty guid-length execution identifier, actual "$executionId""
     fi
 
-    # local  __resultvar=$1
-    # if [[ "$__resultvar" ]]; then
-    #     eval $__resultvar="'$executionId'"
-    # else
     echo "$executionId"
-    # fi
 }
 
 GetLastSuccessfulExecution () {
@@ -32,8 +66,7 @@ GetLastSuccessfulExecution () {
 
     if [ ${#executionId} != 36 ] && [ $executionId != 'NO_LAST_SUCCESSFUL_EXECUTION' ]
     then
-        echo "ERROR: expected a non-empty guid-length execution identifier or known constant when no matching execution found, actual "$executionId""
-        exit 1
+        LogErrorAndExit "ERROR: expected a non-empty guid-length execution identifier or known constant when no matching execution found, actual "$executionId""
     fi
 
     echo "$executionId"
@@ -45,8 +78,7 @@ GetExecutionLastUpdatedTimestamp () {
 
     if ! [[ $executionLastUpdatedTimestamp =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}[\+,-][0-9]{2}:[0-9]{2}$ ]]
     then
-        echo "ERROR: expected a non-empty ISO 8601 datetime with timezone, actual "$executionLastUpdatedTimestamp""
-        exit 1
+        LogErrorAndExit "ERROR: expected a non-empty ISO 8601 datetime with timezone, actual "$executionLastUpdatedTimestamp""
     fi
 
     echo "$executionLastUpdatedTimestamp"
@@ -56,6 +88,7 @@ PersistModels () {
     local executionId=$1
     local modelType=$2
     local basePath=$3
+
     $mcd persist-models $executionId $modelType $basePath "**/*.json" "**/*.csv" "**/*.sql"
 }
 
@@ -71,152 +104,111 @@ CompareModels () {
 
 CompleteExecution () {
     local executionId=$1
-    $mcd complete-execution $executionId
-}
 
-CompareAndAssert () {
-    echo "Comparing load models"
-    $($mcd persist-models $executionId load $loadModelDirectory "*.json")
-    lastSuccessfulExecutionId=$($mcd get-last-successful-execution)
-    changedModels=$($mcd compare-models $lastSuccessfulExecutionId $executionId load)
-
-    echo "Assert changed load models"
-    if [ "$changedModels" != "$1" ]
-    then
-        echo "ERROR: expected "$1", actual "$changedModels""
-        exit 1
-    fi
-}
-
-CompleteAndAssert () {
-    echo "Completing execution"
     $mcd complete-execution $executionId
 
-    echo "Asserting last successful execution"
-    lastSuccessfulExecutionId=$($mcd get-last-successful-execution)
-    if [ $lastSuccessfulExecutionId != $executionId ]
-    then
-        echo "ERROR: expected \"$executionId\", actual '$lastSuccessfulExecutionId'"
-        exit 1
-    fi
+    lastSuccessfulExecId=$(GetLastSuccessfulExecution)
+    AssertAreEqual "$lastSuccessfulExecId" "$executionId"
 }
 
-## Setup
+modelDirectory="./tests/integration/models"
+loadModelDirectory="$modelDirectory/load"
+transformModelDirectory="$modelDirectory/transform"
+load_model_1="load_model_1_$(NewUUID)"
+load_model_2="load_model_2_$(NewUUID)"
+transform_model_1="transform_model_1_$(NewUUID)"
+transform_model_2="transform_model_2_$(NewUUID)"
+transform_model_3="transform_model_3_$(NewUUID)"
+transform_model_4="transform_model_4_$(NewUUID)"
+
+###############
+# Execution 1 #
+###############
+echo -e "\nBeginning execution #1"
+
+# ARRANGE
+## Remove test models' directory, if exists
 rm -rf $modelDirectory
 
 ## Create stub load models
-echo "Creating stub LOAD models: load_model_1.json, load_model_2.json"
+echo "Creating stub LOAD models: load_model_1, load_model_2"
 mkdir -p $loadModelDirectory
-echo "load_model_1" > "$loadModelDirectory/load_model_1.json"
-echo "load_model_2" > "$loadModelDirectory/load_model_2.json"
+echo "load_model_1" > "$loadModelDirectory/$load_model_1.json"
+echo "load_model_2" > "$loadModelDirectory/$load_model_2.json"
 
 ## Create stub transform models
-echo "Creating stub TRANSFORM models: transform_model_1.csv, transform_model_2.sql, transform_model_3.sql"
+echo "Creating stub TRANSFORM models: transform_model_1, transform_model_2, transform_model_3"
 mkdir -p $transformModelDirectory
-echo "transform_model_1" > "$transformModelDirectory/transform_model_1.csv"
-echo "transform_model_2" > "$transformModelDirectory/transform_model_2.sql"
-echo "transform_model_3" > "$transformModelDirectory/transform_model_3.sql"
+echo "transform_model_1" > "$transformModelDirectory/$transform_model_1.csv"
+echo "transform_model_2" > "$transformModelDirectory/$transform_model_2.sql"
+echo "transform_model_3" > "$transformModelDirectory/$transform_model_3.sql"
 
-# Execution 1
-echo "Beginning execution #1"
-
-iter1_ExecId=$(InitExecution)
-echo "iter1_ExecId = $iter1_ExecId"
+# ACT & ASSERT
+iter1_execId=$(InitExecution)
+echo " iter1_execId                                = $iter1_execId"
 
 iter1_lastSuccessfulExecId=$(GetLastSuccessfulExecution)
-echo "iter1_lastSuccessfulExecId = $iter1_lastSuccessfulExecId"
+echo " iter1_lastSuccessfulExecId                  = $iter1_lastSuccessfulExecId"
 
 iter1_lastSuccessfulExecCompletionTimestamp=$(GetExecutionLastUpdatedTimestamp $iter1_lastSuccessfulExecId)
-echo "iter1_lastSuccessfulExecCompletionTimestamp = $iter1_lastSuccessfulExecCompletionTimestamp"
-# GetExecutionLastUpdatedTimestamp $iter1_lastSuccessfulExecId
+echo " iter1_lastSuccessfulExecCompletionTimestamp = $iter1_lastSuccessfulExecCompletionTimestamp"
 
-PersistModels $iter1_ExecId LOAD $loadModelDirectory
-iter1_comparedLoadModels=$(CompareModels $iter1_lastSuccessfulExecId $iter1_ExecId LOAD)
-echo "iter1_comparedLoadModels = '$iter1_comparedLoadModels'"
+PersistModels $iter1_execId LOAD $loadModelDirectory
+iter1_changedLoadModels=$(CompareModels $iter1_lastSuccessfulExecId $iter1_execId LOAD)
+echo " iter1_changedLoadModels                     = '$iter1_changedLoadModels'"
 
-# Assert
-iter1_compareLoadModels_expected="load_model_1 load_model_2"
-if [ "$iter1_comparedLoadModels" != "$iter1_compareLoadModels_expected" ]
-then
-    echo "ERROR: expected '"$iter1_compareLoadModels_expected"', actual '"$iter1_comparedLoadModels"'"
-    exit 1
-fi
+iter1_changedLoadModels_expected="$load_model_1 $load_model_2"
+AssertAreEqual "$iter1_changedLoadModels" "$iter1_changedLoadModels_expected"
 
-PersistModels $iter1_ExecId TRANSFORM $transformModelDirectory
-iter1_comparedTransformModels=$(CompareModels $iter1_lastSuccessfulExecId $iter1_ExecId TRANSFORM)
-echo "iter1_comparedTransformModels = '$iter1_comparedTransformModels'"
+PersistModels $iter1_execId TRANSFORM $transformModelDirectory
+iter1_changedTransformModels=$(CompareModels $iter1_lastSuccessfulExecId $iter1_execId TRANSFORM)
+echo " iter1_changedTransformModels                = '$iter1_changedTransformModels'"
 
-# Assert
-iter1_compareTransformModels_expected="transform_model_1 transform_model_2 transform_model_3"
-if [ "$iter1_comparedTransformModels" != "$iter1_compareTransformModels_expected" ]
-then
-    echo "ERROR: expected '"$iter1_compareTransformModels_expected"', actual '"$iter1_comparedTransformModels"'"
-    exit 1
-fi
+iter1_changedTransformModels_expected="$transform_model_1 $transform_model_2 $transform_model_3"
+AssertAreEqual "$iter1_changedTransformModels" "$iter1_changedTransformModels_expected"
 
-CompleteExecution $iter1_ExecId
+CompleteExecution $iter1_execId
 
-# Execution 2
-echo "Beginning execution #2"
+###############
+# Execution 2 #
+###############
+echo -e "\nBeginning execution #2"
 
-iter2_ExecId=$(InitExecution)
-echo "iter2_ExecId = $iter2_ExecId"
-
-iter2_lastSuccessfulExecId=$(GetLastSuccessfulExecution)
-echo "iter2_lastSuccessfulExecId = $iter2_lastSuccessfulExecId"
-if [ "$iter2_lastSuccessfulExecId" != "$iter1_ExecId" ]
-then
-    echo "ERROR: expected '"$iter1_ExecId"', actual '"$iter2_lastSuccessfulExecId"'"
-    exit 1
-fi
-
-iter2_lastSuccessfulExecCompletionTimestamp=$(GetExecutionLastUpdatedTimestamp $iter1_ExecId)
-echo "iter2_lastSuccessfulExecCompletionTimestamp = $iter2_lastSuccessfulExecCompletionTimestamp"
-
-PersistModels $iter2_ExecId LOAD $loadModelDirectory
-iter2_comparedLoadModels=$(CompareModels $iter1_ExecId $iter2_ExecId LOAD)
-echo "iter2_comparedLoadModels = '$iter2_comparedLoadModels'"
-
-# Assert
-iter2_compareLoadModels_expected=""
-if [ "$iter2_comparedLoadModels" != "$iter2_compareLoadModels_expected" ]
-then
-    echo "ERROR: expected '"$iter2_compareLoadModels_expected"', actual '"$iter2_comparedLoadModels"'"
-    exit 1
-fi
-
+# ARRANGE
+echo "Making no changes to any LOAD models"
 
 echo "Modifying transform_model_2"
-echo "Modified transform_model_2" > "$transformModelDirectory/transform_model_2.sql"
+echo "Modified transform_model_2" > "$transformModelDirectory/$transform_model_2.sql"
+
 echo "Deleting transform_model_3"
-rm -f "$transformModelDirectory/transform_model_3.sql"
-echo "Adding transform_model_2"
-echo "transform_model_4" > "$transformModelDirectory/transform_model_4.sql"
+rm -f "$transformModelDirectory/$transform_model_3.sql"
 
-PersistModels $iter2_ExecId TRANSFORM $transformModelDirectory
-iter2_comparedTransformModels=$(CompareModels $iter1_ExecId $iter2_ExecId TRANSFORM)
-echo "iter2_comparedTransformModels = '$iter2_comparedTransformModels'"
+echo "Adding transform_model_4"
+echo "transform_model_4" > "$transformModelDirectory/$transform_model_4.sql"
 
-# Assert
-iter2_compareTransformModels_expected="transform_model_2 transform_model_4"
-if [ "$iter2_comparedTransformModels" != "$iter2_compareTransformModels_expected" ]
-then
-    echo "ERROR: expected '"$iter2_compareTransformModels_expected"', actual '"$iter2_comparedTransformModels"'"
-    exit 1
-fi
+# ACT & ASSERT
+iter2_execId=$(InitExecution)
+echo " iter2_execId                                = $iter2_execId"
 
-CompleteExecution $iter2_ExecId
+iter2_lastSuccessfulExecId=$(GetLastSuccessfulExecution)
+echo " iter2_lastSuccessfulExecId                  = $iter2_lastSuccessfulExecId"
+AssertAreEqual "$iter2_lastSuccessfulExecId" "$iter1_execId"
 
+iter2_lastSuccessfulExecCompletionTimestamp=$(GetExecutionLastUpdatedTimestamp $iter2_lastSuccessfulExecId)
+echo " iter2_lastSuccessfulExecCompletionTimestamp = $iter2_lastSuccessfulExecCompletionTimestamp"
 
-# CompareAndAssert "load_model_1 load_model_2"
-# CompleteAndAssert
+PersistModels $iter2_execId LOAD $loadModelDirectory
+iter2_changedLoadModels=$(CompareModels $iter2_lastSuccessfulExecId $iter2_execId LOAD)
+echo " iter2_changedLoadModels                     = '$iter2_changedLoadModels'"
 
-# Modify load_model_1
-# echo "Modifying load_model_1"
-# echo "" > "$loadModelDirectory/load_model_1.json"
+iter2_compareLoadModels_expected=""
+AssertAreEqual "$iter2_changedLoadModels" "$iter2_compareLoadModels_expected"
 
-# Execution 2
-# echo "Beginning execution #2"
-# InitExecution
-# CompareAndAssert "load_model_1"
-# CompleteAndAssert
+PersistModels $iter2_execId TRANSFORM $transformModelDirectory
+iter2_changedTransformModels=$(CompareModels $iter2_lastSuccessfulExecId $iter2_execId TRANSFORM)
+echo " iter2_changedTransformModels                = '$iter2_changedTransformModels'"
+
+iter2_compareTransformModels_expected="$transform_model_2 $transform_model_4"
+AssertAreEqual "$iter2_changedTransformModels" "$iter2_compareTransformModels_expected"
+
+CompleteExecution $iter2_execId

--- a/tests/integration/test_integration.sh
+++ b/tests/integration/test_integration.sh
@@ -5,11 +5,73 @@ set -e
 
 # Bootstrap
 ## Aliases
-loadModelDirectory="./tests/integration/models/load"
-mcd="pipenv run python -m mcd postgresql+psycopg2://postgres:travisci@localhost:5432/postgres"
+modelDirectory="./tests/integration/models"
+loadModelDirectory="$modelDirectory/load"
+transformModelDirectory="$modelDirectory/transform"
+mcd="pipenv run python -m mcd postgresql+psycopg2://postgres:postgres@localhost:5432/postgres"
 
 InitExecution () {
-    executionId=$($mcd init-execution)
+    local executionId=$($mcd init-execution)
+
+    if [ ${#executionId} -ne 36 ]
+    then
+        echo "ERROR: expected a non-empty guid-length execution identifier, actual "$executionId""
+        exit 1
+    fi
+
+    # local  __resultvar=$1
+    # if [[ "$__resultvar" ]]; then
+    #     eval $__resultvar="'$executionId'"
+    # else
+    echo "$executionId"
+    # fi
+}
+
+GetLastSuccessfulExecution () {
+    local executionId=$($mcd get-last-successful-execution)
+
+    if [ ${#executionId} != 36 ] && [ $executionId != 'NO_LAST_SUCCESSFUL_EXECUTION' ]
+    then
+        echo "ERROR: expected a non-empty guid-length execution identifier or known constant when no matching execution found, actual "$executionId""
+        exit 1
+    fi
+
+    echo "$executionId"
+}
+
+GetExecutionLastUpdatedTimestamp () {
+    local executionId=$1
+    local executionLastUpdatedTimestamp=$($mcd get-execution-last-updated-timestamp $executionId)
+
+    if ! [[ $executionLastUpdatedTimestamp =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}[\+,-][0-9]{2}:[0-9]{2}$ ]]
+    then
+        echo "ERROR: expected a non-empty ISO 8601 datetime with timezone, actual "$executionLastUpdatedTimestamp""
+        exit 1
+    fi
+
+    echo "$executionLastUpdatedTimestamp"
+}
+
+PersistModels () {
+    local executionId=$1
+    local modelType=$2
+    local basePath=$3
+    $mcd persist-models $executionId $modelType $basePath "**/*.json" "**/*.csv" "**/*.sql"
+}
+
+CompareModels () {
+    local previousExecutionId=$1
+    local currentExecutionId=$2
+    local modelType=$3
+
+    local result=$($mcd compare-models $previousExecutionId $currentExecutionId $modelType)
+
+    echo "$result"
+}
+
+CompleteExecution () {
+    local executionId=$1
+    $mcd complete-execution $executionId
 }
 
 CompareAndAssert () {
@@ -39,24 +101,122 @@ CompleteAndAssert () {
     fi
 }
 
+## Setup
+rm -rf $modelDirectory
+
 ## Create stub load models
-echo "Creating stub load models: load_model_1.json, load_model_2.json"
+echo "Creating stub LOAD models: load_model_1.json, load_model_2.json"
 mkdir -p $loadModelDirectory
 echo "load_model_1" > "$loadModelDirectory/load_model_1.json"
 echo "load_model_2" > "$loadModelDirectory/load_model_2.json"
 
+## Create stub transform models
+echo "Creating stub TRANSFORM models: transform_model_1.csv, transform_model_2.sql, transform_model_3.sql"
+mkdir -p $transformModelDirectory
+echo "transform_model_1" > "$transformModelDirectory/transform_model_1.csv"
+echo "transform_model_2" > "$transformModelDirectory/transform_model_2.sql"
+echo "transform_model_3" > "$transformModelDirectory/transform_model_3.sql"
+
 # Execution 1
 echo "Beginning execution #1"
-InitExecution
-CompareAndAssert "load_model_1 load_model_2"
-CompleteAndAssert
 
-# Modify load_model_1
-echo "Modifying load_model_1"
-echo "" > "$loadModelDirectory/load_model_1.json"
+iter1_ExecId=$(InitExecution)
+echo "iter1_ExecId = $iter1_ExecId"
+
+iter1_lastSuccessfulExecId=$(GetLastSuccessfulExecution)
+echo "iter1_lastSuccessfulExecId = $iter1_lastSuccessfulExecId"
+
+iter1_lastSuccessfulExecCompletionTimestamp=$(GetExecutionLastUpdatedTimestamp $iter1_lastSuccessfulExecId)
+echo "iter1_lastSuccessfulExecCompletionTimestamp = $iter1_lastSuccessfulExecCompletionTimestamp"
+# GetExecutionLastUpdatedTimestamp $iter1_lastSuccessfulExecId
+
+PersistModels $iter1_ExecId LOAD $loadModelDirectory
+iter1_comparedLoadModels=$(CompareModels $iter1_lastSuccessfulExecId $iter1_ExecId LOAD)
+echo "iter1_comparedLoadModels = '$iter1_comparedLoadModels'"
+
+# Assert
+iter1_compareLoadModels_expected="load_model_1 load_model_2"
+if [ "$iter1_comparedLoadModels" != "$iter1_compareLoadModels_expected" ]
+then
+    echo "ERROR: expected '"$iter1_compareLoadModels_expected"', actual '"$iter1_comparedLoadModels"'"
+    exit 1
+fi
+
+PersistModels $iter1_ExecId TRANSFORM $transformModelDirectory
+iter1_comparedTransformModels=$(CompareModels $iter1_lastSuccessfulExecId $iter1_ExecId TRANSFORM)
+echo "iter1_comparedTransformModels = '$iter1_comparedTransformModels'"
+
+# Assert
+iter1_compareTransformModels_expected="transform_model_1 transform_model_2 transform_model_3"
+if [ "$iter1_comparedTransformModels" != "$iter1_compareTransformModels_expected" ]
+then
+    echo "ERROR: expected '"$iter1_compareTransformModels_expected"', actual '"$iter1_comparedTransformModels"'"
+    exit 1
+fi
+
+CompleteExecution $iter1_ExecId
 
 # Execution 2
 echo "Beginning execution #2"
-InitExecution
-CompareAndAssert "load_model_1"
-CompleteAndAssert
+
+iter2_ExecId=$(InitExecution)
+echo "iter2_ExecId = $iter2_ExecId"
+
+iter2_lastSuccessfulExecId=$(GetLastSuccessfulExecution)
+echo "iter2_lastSuccessfulExecId = $iter2_lastSuccessfulExecId"
+if [ "$iter2_lastSuccessfulExecId" != "$iter1_ExecId" ]
+then
+    echo "ERROR: expected '"$iter1_ExecId"', actual '"$iter2_lastSuccessfulExecId"'"
+    exit 1
+fi
+
+iter2_lastSuccessfulExecCompletionTimestamp=$(GetExecutionLastUpdatedTimestamp $iter1_ExecId)
+echo "iter2_lastSuccessfulExecCompletionTimestamp = $iter2_lastSuccessfulExecCompletionTimestamp"
+
+PersistModels $iter2_ExecId LOAD $loadModelDirectory
+iter2_comparedLoadModels=$(CompareModels $iter1_ExecId $iter2_ExecId LOAD)
+echo "iter2_comparedLoadModels = '$iter2_comparedLoadModels'"
+
+# Assert
+iter2_compareLoadModels_expected=""
+if [ "$iter2_comparedLoadModels" != "$iter2_compareLoadModels_expected" ]
+then
+    echo "ERROR: expected '"$iter2_compareLoadModels_expected"', actual '"$iter2_comparedLoadModels"'"
+    exit 1
+fi
+
+
+echo "Modifying transform_model_2"
+echo "Modified transform_model_2" > "$transformModelDirectory/transform_model_2.sql"
+echo "Deleting transform_model_3"
+rm -f "$transformModelDirectory/transform_model_3.sql"
+echo "Adding transform_model_2"
+echo "transform_model_4" > "$transformModelDirectory/transform_model_4.sql"
+
+PersistModels $iter2_ExecId TRANSFORM $transformModelDirectory
+iter2_comparedTransformModels=$(CompareModels $iter1_ExecId $iter2_ExecId TRANSFORM)
+echo "iter2_comparedTransformModels = '$iter2_comparedTransformModels'"
+
+# Assert
+iter2_compareTransformModels_expected="transform_model_2 transform_model_4"
+if [ "$iter2_comparedTransformModels" != "$iter2_compareTransformModels_expected" ]
+then
+    echo "ERROR: expected '"$iter2_compareTransformModels_expected"', actual '"$iter2_comparedTransformModels"'"
+    exit 1
+fi
+
+CompleteExecution $iter2_ExecId
+
+
+# CompareAndAssert "load_model_1 load_model_2"
+# CompleteAndAssert
+
+# Modify load_model_1
+# echo "Modifying load_model_1"
+# echo "" > "$loadModelDirectory/load_model_1.json"
+
+# Execution 2
+# echo "Beginning execution #2"
+# InitExecution
+# CompareAndAssert "load_model_1"
+# CompleteAndAssert

--- a/tests/integration/test_integration.sh
+++ b/tests/integration/test_integration.sh
@@ -60,7 +60,7 @@ AssertAreEqual () {
 InitExecution () {
     local executionId=$($mcd init-execution)
 
-    if [ ${#executionId} -ne 36 ]
+    if [ ${#executionId} != 36 ]
     then
         LogErrorAndExit "ERROR: expected a non-empty guid-length execution identifier, actual "$executionId""
     fi

--- a/tests/integration/test_integration.sh
+++ b/tests/integration/test_integration.sh
@@ -189,7 +189,7 @@ echo "transform_model_2" > "$transformModelDirectory/$transform_model_2.sql"
 echo "transform_model_3" > "$transformModelDirectory/$transform_model_3.sql"
 
 # ACT & ASSERT
-iter1_expected_lastSuccessfulExecId=""
+iter1_expected_lastSuccessfulExecId="" # pass in empty string to skip test since we don't know the past state of the pipeline
 iter1_expected_changedLoadModels="$load_model_1 $load_model_2"
 iter1_expected_changedTransformModels="$transform_model_1 $transform_model_2 $transform_model_3"
 ExecuteAndAssert "1" "$iter1_expected_lastSuccessfulExecId" "$iter1_expected_changedLoadModels" "$iter1_expected_changedTransformModels" iter1_execId


### PR DESCRIPTION
Must do:
- add coverage for all new commands in integration tests
- make integration tests re-runnable
- apply DRY to assist multiple execution iterations
- log passing tests post assertion

Had to do:
- move from plain Bourne shell to Bash shell since we now use a 3rd-party gist to generate UUIDs to allow us to re-run integration tests on dev machines.